### PR TITLE
Making click targets for nav items larger.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -74,12 +74,13 @@ frame, iframe {
 .nav li {
   display: inline-block;
   list-style: none;
-  padding: 12pt 12pt;
 }
 
 .nav li a {
   color: white;
   text-decoration: none;
+  display: inline-block;
+  padding: 12pt 12pt;
 }
 
 .nav li a:hover, .nav li a:focus {


### PR DESCRIPTION
Although the highlight for a selected menu item is large, the click target for items in the nav menu is only a single list item. This patch makes moves the 12pt padding onto the link itself, making the nav require less precision to use.
