### PR TITLE
Update z02-parts-of-a-graph.md

### DIFF
--- a/z02-parts-of-a-graph.md
+++ b/z02-parts-of-a-graph.md
@@ -235,7 +235,7 @@ say, "hey, I want to build an axis that".
 
   <iframe class="example"
     height="180"
-    src="{{ "/examples/axes" | prepend: site.baseurl }}">
+    src="{{ "/examples/axes/" | prepend: site.baseurl }}">
   </iframe>
 </div>
 


### PR DESCRIPTION
Fix 301 to insecure version by adding trailing slash. Kills mixed content warning.